### PR TITLE
chore: centralize DTO exports

### DIFF
--- a/src/booking/booking.controller.ts
+++ b/src/booking/booking.controller.ts
@@ -18,7 +18,7 @@ import {
   UpdateBookingDto,
   TimeSlotQueryDto,
   BookingResponseDto,
-} from './dto/booking.dto';
+} from './dto';
 import { Public } from '../auth/decorators/public.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 

--- a/src/booking/booking.service.ts
+++ b/src/booking/booking.service.ts
@@ -12,7 +12,7 @@ import {
   UpdateBookingDto,
   BookingResponseDto,
   BookingStatus,
-} from './dto/booking.dto';
+} from './dto';
 
 @Injectable()
 export class BookingService {

--- a/src/booking/dto/index.ts
+++ b/src/booking/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './booking.dto';
+

--- a/src/estimate/dto/index.ts
+++ b/src/estimate/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './estimate.dto';
+

--- a/src/estimate/estimate.controller.ts
+++ b/src/estimate/estimate.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Post, Body, Get, Query } from '@nestjs/common';
 import { EstimateService } from './estimate.service';
-import { CreateEstimateDto, EstimateResponseDto } from './dto/estimate.dto';
+import { CreateEstimateDto, EstimateResponseDto } from './dto';
 import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('estimate')

--- a/src/estimate/estimate.service.ts
+++ b/src/estimate/estimate.service.ts
@@ -3,7 +3,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { PricingService } from './services/pricing.service';
 import { VehicleService } from './services/vehicle.service';
 import { GeocodeService } from './services/geocode.service';
-import { CreateEstimateDto, EstimateResponseDto } from './dto/estimate.dto';
+import { CreateEstimateDto, EstimateResponseDto } from './dto';
 
 @Injectable()
 export class EstimateService {

--- a/src/upload/dto/index.ts
+++ b/src/upload/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './upload.dto';
+

--- a/src/upload/upload.controller.ts
+++ b/src/upload/upload.controller.ts
@@ -26,7 +26,7 @@ import {
   FileResponseDto,
   BulkUploadResponseDto,
   FileCategory,
-} from './dto/upload.dto';
+} from './dto';
 
 @Controller('upload')
 export class UploadController {

--- a/src/upload/upload.service.ts
+++ b/src/upload/upload.service.ts
@@ -14,7 +14,7 @@ import {
   FileResponseDto,
   BulkUploadResponseDto,
   FileCategory,
-} from './dto/upload.dto';
+} from './dto';
 
 @Injectable()
 export class UploadService {


### PR DESCRIPTION
## Summary
- re-export booking DTOs from single index
- centralize estimate DTO imports
- simplify upload module DTO access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a2b009dcc832890ae31fb012224e4